### PR TITLE
Update SeqAn3 and sharg

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -26,10 +26,10 @@ jobs:
             cc: "gcc-12"
             build_type: Release
 
-          - name: "gcc11"
-            install: "g++-11"
-            cxx: "g++-11"
-            cc: "gcc-11"
+          - name: "gcc13"
+            install: "g++-13"
+            cxx: "g++-13"
+            cc: "gcc-13"
             build_type: Release
 
     steps:
@@ -79,11 +79,12 @@ jobs:
           CXX: ${{ matrix.cxx }}
           CC: ${{ matrix.cc }}
         run: |
-          mkdir build
-          cd build
-          cmake ../rlm -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
+          cmake -S rlm -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DBUILD_TESTING=ON \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
 
-      - name: Build tests
+      - name: Build
         env:
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -92,10 +93,11 @@ jobs:
           CCACHE_MAXSIZE: 500M
         run: |
           ccache -p || true
-          cd build
-          make -k -j2
+          cmake --build build --parallel 2 --config ${{ matrix.build_type }} --target build_tests
 
       - name: Run tests
         run: |
-          cd build
-          ctest . -j2 --output-on-failure
+          ctest --test-dir build \
+            -C ${{ matrix.build_type }} \
+            --output-on-failure \
+            --parallel 2

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.10.0
+  CMAKE_VERSION: 3.20.0
   SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 
@@ -27,9 +27,9 @@ jobs:
             cc: "gcc-12"
             build_type: Release
 
-          - name: "gcc11"
-            cxx: "g++-11"
-            cc: "gcc-11"
+          - name: "gcc13"
+            cxx: "g++-13"
+            cc: "gcc-13"
             build_type: Release
 
     steps:
@@ -70,9 +70,10 @@ jobs:
           CXX: ${{ matrix.cxx }}
           CC: ${{ matrix.cc }}
         run: |
-          mkdir build
-          cd build
-          cmake ../rlm -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
+          cmake -S rlm -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
+            -DBUILD_TESTING=ON
 
       - name: Build tests
         env:
@@ -83,10 +84,11 @@ jobs:
           CCACHE_MAXSIZE: 500M
         run: |
           ccache -p || true
-          cd build
-          make -k -j2
+          cmake --build build --parallel 2 --config ${{ matrix.build_type }} --target build_tests
 
       - name: Run tests
         run: |
-          cd build
-          ctest . -j2 --output-on-failure
+          ctest --test-dir build \
+            -C ${{ matrix.build_type }} \
+            --output-on-failure \
+            --parallel 2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "lib/seqan3"]
-	path = lib/seqan3
-	url = https://github.com/seqan/seqan3.git
-[submodule "lib/sharg-parser"]
-	path = lib/sharg-parser
-	url = https://github.com/seqan/sharg-parser.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,19 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.20)
 
 ## CUSTOMISE
 
 # Define the application name and version.
 project (RLM VERSION 1.2.0)
+
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    message(FATAL_ERROR
+        "RLM currently supports GCC only. Detected: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+endif ()
+
+# C++20 (required by SeqAn3)
+set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
 
 ## BUILD
 
@@ -24,9 +34,28 @@ string (ASCII 27 Esc)
 set (FontBold "${Esc}[1m")
 set (FontReset "${Esc}[m")
 
-# Dependency: SeqAn3, sharg-parser.
-find_package (SeqAn3 QUIET REQUIRED HINTS lib/seqan3/build_system)
-find_package (sharg QUIET REQUIRED HINTS lib/sharg-parser/build_system)
+# Dependencies via CPM
+include (${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
+
+# Pin versions
+CPMAddPackage(
+  NAME seqan3
+  GITHUB_REPOSITORY seqan/seqan3
+  GIT_TAG 3.4.0
+)
+
+CPMAddPackage(
+  NAME sharg-parser
+  GITHUB_REPOSITORY seqan/sharg-parser
+  GIT_TAG 1.2.1
+)
+
+CPMAddPackage(
+  NAME googletest
+  GITHUB_REPOSITORY google/googletest
+  GIT_TAG v1.15.2
+  OPTIONS "INSTALL_GTEST OFF"
+)
 
 # GCC12 and above: Disable warning about std::hardware_destructive_interference_size not being ABI-stable.
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Read level DNA methylation analysis of bisulfite converted sequencing data
 For detailed documentation and usage examples, please visit the [Wiki](https://github.com/sarahet/RLM/wiki).
 
 ## Dependencies
-* GCC   (minimum required version: 11, no other compiler is currently supported)
-* CMake (minimum required version: 3.8)
+* GCC   (minimum required version: 12, no other compiler is currently supported)
+* CMake (minimum required version: 3.20)
 * zlib  (minimum required version: 1.2)
 
 **Attention:** Due to the requirements of the SeqAn3 library, only the latest minor GCC releases are supported for each major version.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set (CPM_DOWNLOAD_VERSION 0.42.1)
+set (CPM_HASH_SUM "f3a6dcc6a04ce9e7f51a127307fa4f699fb2bade357a8eb4c5b45df76e1dc6a5")
+
+if (CPM_SOURCE_CACHE)
+    set (CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif (DEFINED ENV{CPM_SOURCE_CACHE})
+    set (CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else ()
+    set (CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif ()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component (CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file (DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+      ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include (${CPM_DOWNLOAD_LOCATION})

--- a/cmake/test/config.cmake
+++ b/cmake/test/config.cmake
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2006-2025 Knut Reinert & Freie Universität Berlin
+# SPDX-FileCopyrightText: 2016-2025 Knut Reinert & MPI für molekulare Genetik
+# SPDX-License-Identifier: CC0-1.0
+
+list (APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure") # Must be before `enable_testing ()`.
+list (APPEND CMAKE_CTEST_ARGUMENTS "--no-tests=error") # Must be before `enable_testing ()`.
+
+enable_testing ()
+
+# Set directories for test output files, input data and binaries.
+file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)
+add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
+add_definitions (-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
+add_definitions (-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
+
+# Add the test interface library.
+if (NOT TARGET ${PROJECT_NAME}_test)
+    add_library (${PROJECT_NAME}_test INTERFACE)
+    target_link_libraries (${PROJECT_NAME}_test INTERFACE GTest::gtest_main ${PROJECT_NAME}_lib)
+    add_library (${PROJECT_NAME}::test ALIAS ${PROJECT_NAME}_test)
+    target_include_directories(${PROJECT_NAME}_test INTERFACE "${seqan3_SOURCE_DIR}/test/include")
+endif ()
+
+# Add the check target that builds and runs tests.
+add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS})
+
+get_directory_property (${PROJECT_NAME}_targets DIRECTORY "${${PROJECT_NAME}_SOURCE_DIR}/src" BUILDSYSTEM_TARGETS)
+foreach (target IN LISTS ${PROJECT_NAME}_targets)
+    get_target_property (type ${target} TYPE)
+    if (type STREQUAL "EXECUTABLE")
+        list (APPEND ${PROJECT_NAME}_EXECUTABLE_LIST ${target})
+    endif ()
+endforeach ()
+unset (${PROJECT_NAME}_targets)
+
+macro (add_app_test test_filename)
+    file (RELATIVE_PATH source_file "${${PROJECT_NAME}_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${test_filename}")
+    get_filename_component (target "${source_file}" NAME_WE)
+
+    add_executable (${target} ${test_filename})
+    target_link_libraries (${target} ${PROJECT_NAME}::test)
+
+    add_dependencies (${target} ${${PROJECT_NAME}_EXECUTABLE_LIST})
+    add_dependencies (check ${target})
+
+    add_test (NAME ${target} COMMAND ${target})
+
+    unset (source_file)
+    unset (target)
+endmacro ()
+

--- a/cmake/test/config.cmake
+++ b/cmake/test/config.cmake
@@ -7,6 +7,13 @@ list (APPEND CMAKE_CTEST_ARGUMENTS "--no-tests=error") # Must be before `enable_
 
 enable_testing ()
 
+# Ensure global test build target exists even if this file is included late or multiple times.
+macro(rlm_ensure_build_tests_target)
+    if (NOT TARGET build_tests)
+        add_custom_target(build_tests)
+    endif ()
+endmacro()
+
 # Set directories for test output files, input data and binaries.
 file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)
 add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
@@ -22,7 +29,13 @@ if (NOT TARGET ${PROJECT_NAME}_test)
 endif ()
 
 # Add the check target that builds and runs tests.
-add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS})
+rlm_ensure_build_tests_target()
+
+add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+add_dependencies(check build_tests)
 
 get_directory_property (${PROJECT_NAME}_targets DIRECTORY "${${PROJECT_NAME}_SOURCE_DIR}/src" BUILDSYSTEM_TARGETS)
 foreach (target IN LISTS ${PROJECT_NAME}_targets)
@@ -34,6 +47,8 @@ endforeach ()
 unset (${PROJECT_NAME}_targets)
 
 macro (add_app_test test_filename)
+    rlm_ensure_build_tests_target()
+
     file (RELATIVE_PATH source_file "${${PROJECT_NAME}_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${test_filename}")
     get_filename_component (target "${source_file}" NAME_WE)
 
@@ -41,11 +56,13 @@ macro (add_app_test test_filename)
     target_link_libraries (${target} ${PROJECT_NAME}::test)
 
     add_dependencies (${target} ${${PROJECT_NAME}_EXECUTABLE_LIST})
-    add_dependencies (check ${target})
 
-    add_test (NAME ${target} COMMAND ${target})
+    # Build-only aggregation target
+    add_dependencies (build_tests ${target})
+
+    # CTest uses the actual produced executable path
+    add_test (NAME ${target} COMMAND $<TARGET_FILE:${target}>)
 
     unset (source_file)
     unset (target)
 endmacro ()
-

--- a/include/argument_parsing.hpp
+++ b/include/argument_parsing.hpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -21,6 +21,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+#include <sharg/parser.hpp>
+
 // Struct that stores command line arguments
 struct cmd_arguments
 {
@@ -31,7 +37,6 @@ struct cmd_arguments
     std::filesystem::path output_file_entropy{"output_entropy.bed"};
     std::filesystem::path output_file_pdr{"output_pdr.bed"};
 
-    uint32_t verbosity = 0;
     uint32_t mapq_filter = 30;
     uint32_t coverage_filter = 10;
 
@@ -43,11 +48,11 @@ struct cmd_arguments
 };
 
 // Function to initialize the argument parser
-void initialise_argument_parser(sharg::parser & parser, cmd_arguments & args)
+inline void initialise_argument_parser(sharg::parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Sara Hetzel";
     parser.info.short_description = "Read level DNA methylation analysis of bisulfite converted sequencing data.";
-    parser.info.version = "1.2.0";
+    parser.info.version = "1.3.0";
 
     parser.add_option(args.bam_file,
                       sharg::config{.short_id    = 'b',
@@ -73,8 +78,7 @@ void initialise_argument_parser(sharg::parser & parser, cmd_arguments & args)
     parser.add_option(args.score,
                       sharg::config{.short_id    = 's',
                                     .long_id     = "score",
-                                    .description = "The score(s) to compute. For 'entropy', 'pdr' and 'all' the single read output is always computed.",
-                                    .required    = true,
+                                    .description = "Select score output mode. For 'entropy', 'pdr' and 'all' the single read output is always computed.",
                                     .validator   = sharg::value_list_validator{"single_read", "entropy", "pdr", "all"}});
 
     parser.add_option(args.aligner,

--- a/include/data_structures.hpp
+++ b/include/data_structures.hpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -21,6 +21,11 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <tuple>
 #include <vector>
 
 #include <seqan3/io/sam_file/sam_tag_dictionary.hpp>
@@ -48,7 +53,7 @@ _score_name_to_enum(std::string const & str)
     else if (str == "all")
         return score_type::ALL;
 
-    return score_type::SINGLE_READ;
+    throw std::invalid_argument("Unknown score: " + str);
 }
 
 // Define aligner types
@@ -72,7 +77,7 @@ _aligner_name_to_enum(std::string const & str)
     else if (str == "gem")
         return align_type::GEM;
 
-    return align_type::BSMAP;
+    throw std::invalid_argument("Unknown aligner: " + str);
 }
 
 // Define sequencing types
@@ -106,7 +111,7 @@ _mate_type_to_enum(std::string const & str)
     else if (str == "PE")
         return mate_type::PE;
 
-    return mate_type::PE;
+    throw std::invalid_argument("Unknown mate type: " + str);
 }
 
 // Define read type
@@ -129,7 +134,7 @@ _read_tag_bsmap_to_enum(std::string const & str)
     else if (str == "--")
         return read_type::REV;
 
-    return read_type::FWD;
+    throw std::invalid_argument("Unknown read type for BSMAP: " + str);
 }
 
 // Get original strand from BISMARK alignment
@@ -141,7 +146,7 @@ _read_tag_bismark_to_enum(std::string const & str)
     else if (str == "GA")
         return read_type::REV;
 
-    return read_type::FWD;
+    throw std::invalid_argument("Unknown read type for BISMARK: " + str);
 }
 
 // Get original strand from segemehl alignment
@@ -153,7 +158,7 @@ _read_tag_segemehl_to_enum(std::string const & str)
     else if (str == "F1/GA")
         return read_type::REV;
 
-    return read_type::FWD;
+    throw std::invalid_argument("Unknown read type for segemehl: " + str);
 }
 
 // Get original strand from GEM alignment
@@ -165,7 +170,7 @@ _read_tag_gem_to_enum(std::string const & str)
     else if (str == "G")
         return read_type::REV;
 
-    return read_type::FWD;
+    throw std::invalid_argument("Unknown read type for GEM: " + str);
 }
 
 // Tag used to separate overloads for different score calculations

--- a/include/methylation_scores.hpp
+++ b/include/methylation_scores.hpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -21,8 +21,13 @@
 
 #pragma once
 
+#include <cassert>
 #include <cmath>
-#include <numeric>
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
 
 #include "data_structures.hpp"
 
@@ -31,51 +36,66 @@ using num_discordant_reads_t = uint32_t;
 using sum_transitions_t = double;
 using num_methyl_cpgs_t = uint32_t;
 
-// Calculate transirion score of a single read
-double calculate_transitions_per_read(std::vector<uint16_t> const & cpg_config)
+// Calculate transition score of a single read
+inline double calculate_transitions_per_read(std::vector<uint16_t> const & cpg_config)
 {
     uint16_t transitions = 0;
-    for (size_t i = 0; i < (cpg_config.size() - 1); i++)
+
+    if (cpg_config.size() > 1)
     {
-        if (cpg_config[i] != cpg_config[i+1])
-            transitions++;
+        for (size_t i = 0; i < (cpg_config.size() - 1); i++)
+        {
+            if (cpg_config[i] != cpg_config[i+1])
+                transitions++;
+        }
+        return static_cast<double>(transitions) / (cpg_config.size() - 1);
     }
-    return static_cast<double>(transitions) / (cpg_config.size() - 1);
+    else return 0;
 }
 
 // Calculate discordance of a single read
-uint16_t calculate_discordance_per_read(std::vector<uint16_t> const & cpg_config)
+inline uint16_t calculate_discordance_per_read(std::vector<uint16_t> const & cpg_config)
 {
     uint16_t transitions = 0;
-    for (size_t i = 0; i < (cpg_config.size() - 1); i++)
+    
+    if (cpg_config.size() > 1)
     {
-        if (cpg_config[i] != cpg_config[i+1])
-            transitions++;
+        for (size_t i = 0; i < (cpg_config.size() - 1); i++)
+        {
+            if (cpg_config[i] != cpg_config[i+1])
+                transitions++;
+        }
+        return transitions == 0 ? 0 : 1;
     }
-    return transitions == 0 ? 0 : 1;
+    else return 0;
 }
 
 // Calculate average RTS for a CpG
-double calculate_avg_transitions_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
+inline double calculate_avg_transitions_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
 {
+    assert(std::get<0>(position_counts) > 0);
     return std::get<2>(position_counts) / std::get<0>(position_counts);
 }
 
 // Calculate average discordance for a CpG
-double calculate_avg_discordance_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
+inline double calculate_avg_discordance_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
 {
+    assert(std::get<0>(position_counts) > 0);
     return static_cast<double>(std::get<1>(position_counts)) / std::get<0>(position_counts);
 }
 
 // Calculate average methylation for a CpG
-double calculate_avg_methylation_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
+inline double calculate_avg_methylation_across_reads(std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts)
 {
+    assert(std::get<0>(position_counts) > 0);
     return static_cast<double>(std::get<3>(position_counts)) / std::get<0>(position_counts);
 }
 
 // Calculate entropy for a 4-mer
-double calculate_entropy_across_reads(std::vector<uint32_t> const & epialleles, uint32_t const & num_reads)
+inline double calculate_entropy_across_reads(std::vector<uint32_t> const & epialleles, uint32_t num_reads)
 {
+    assert(num_reads > 0);
+
     double entropy = 0;
 
     for (size_t i = 0; i < epialleles.size(); i++)
@@ -89,8 +109,10 @@ double calculate_entropy_across_reads(std::vector<uint32_t> const & epialleles, 
 }
 
 // Calculate epipolymorphism for a 4-mer
-double calculate_epipolymorphism_across_reads(std::vector<uint32_t> const & epialleles, uint32_t const & num_reads)
+inline double calculate_epipolymorphism_across_reads(std::vector<uint32_t> const & epialleles, uint32_t num_reads)
 {
+    assert(num_reads > 0);
+
     double epipolymorphism = 0;
 
     for (size_t i = 0; i < epialleles.size(); i++)
@@ -103,8 +125,11 @@ double calculate_epipolymorphism_across_reads(std::vector<uint32_t> const & epia
 }
 
 // Calculate average methylation for a 4-mer
-double calculate_avg_kmer_methylation_across_reads(std::vector<uint32_t> const & epialleles, uint32_t const & num_reads)
+inline double calculate_avg_kmer_methylation_across_reads(std::vector<uint32_t> const & epialleles, uint32_t num_reads)
 {
+    assert(num_reads > 0);
+    assert(epialleles.size() == 16);
+
     uint32_t methylated_cpgs =
     epialleles[1] * 1 +
     epialleles[2] * 1 +

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -21,15 +21,20 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstdint>
+#include <deque>
+#include <fstream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include "methylation_scores.hpp"
 
-using num_reads_t = uint32_t;
-using num_discordant_reads_t = uint32_t;
-using sum_transitions_t = double;
-using num_methyl_cpgs_t = uint32_t;
-
 // Write header for 'single_read' mode
-void write_header_read_info(std::ofstream & output_stream)
+inline void write_header_read_info(std::ofstream & output_stream)
 {
     if (output_stream.is_open())
     {
@@ -51,7 +56,7 @@ void write_header_read_info(std::ofstream & output_stream)
 }
 
 // Write header for 'entropy' mode
-void write_header_entropy(std::ofstream & output_stream)
+inline void write_header_entropy(std::ofstream & output_stream)
 {
     if (output_stream.is_open())
     {
@@ -86,7 +91,7 @@ void write_header_entropy(std::ofstream & output_stream)
 }
 
 // Write header for 'pdr' mode
-void write_header_pdr(std::ofstream & output_stream)
+inline void write_header_pdr(std::ofstream & output_stream)
 {
     if (output_stream.is_open())
     {
@@ -105,13 +110,15 @@ void write_header_pdr(std::ofstream & output_stream)
 }
 
 // Write record for 'entropy' mode
-void write_record_entropy(std::ofstream & output_stream,
+inline void write_record_entropy(std::ofstream & output_stream,
                           std::deque<std::string> const & ref_ids,
                           GenomePosition const & pos,
                           std::vector<uint32_t> const & epialleles,
-                          uint32_t const & coverage_filter)
+                          uint32_t coverage_filter)
 {
-    uint32_t coverage = std::accumulate(epialleles.begin(), epialleles.end(), 0);
+    assert(epialleles.size() == 16);
+    
+    uint32_t coverage = std::accumulate(epialleles.begin(), epialleles.end(), uint32_t{0});
     if (coverage < coverage_filter)
         return;
 
@@ -141,11 +148,11 @@ void write_record_entropy(std::ofstream & output_stream,
 }
 
 // Write record for 'pdr' mode
-void write_record_pdr(std::ofstream & output_stream,
+inline void write_record_pdr(std::ofstream & output_stream,
                       std::deque<std::string> const & ref_ids,
                       GenomePosition const & pos,
                       std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> const & position_counts,
-                      uint32_t const & coverage_filter)
+                      uint32_t coverage_filter)
 {
     if (std::get<0>(position_counts) < coverage_filter)
         return;

--- a/include/process_record.hpp
+++ b/include/process_record.hpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -21,38 +21,54 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <deque>
+#include <fstream>
+#include <map>
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/views/to_rank.hpp>
+
 #include "methylation_scores.hpp"
 
 using seqan3::operator""_dna5;
-using num_reads_t = uint32_t;
-using num_discordant_reads_t = uint32_t;
-using sum_transitions_t = double;
-using num_methyl_cpgs_t = uint32_t;
 
 // Find positions of all CpGs in a sequence
 template <typename ref_type>
-std::vector<uint16_t> find_cpg_pos(ref_type const & reference)
+std::vector<uint32_t> find_cpg_pos(ref_type const & reference)
 {
-    std::vector<uint16_t> occurrencs;
+    std::vector<uint32_t> occurrences;
     seqan3::dna5_vector pattern = "CG"_dna5;
     auto cpg_pos = std::search(reference.begin(), reference.end(), pattern.begin(), pattern.end());
     while (cpg_pos != reference.end())
     {
-        occurrencs.push_back(cpg_pos - reference.begin());
+        occurrences.push_back(cpg_pos - reference.begin());
         ++cpg_pos;
         cpg_pos = std::search(cpg_pos, reference.end(), pattern.begin(), pattern.end());
     }
-    return occurrencs;
+    return occurrences;
 }
 
 // Insert CpG into map to store it until all BAM records are read
-void insert_CpG(size_t const & reference_id,
+inline void insert_CpG(size_t const & reference_id,
                 size_t const & reference_position,
                 std::map<GenomePosition, std::tuple<num_reads_t, num_discordant_reads_t, sum_transitions_t, num_methyl_cpgs_t> > & all_CpGs,
-                std::vector<uint16_t> const & cpg_pos,
+                std::vector<uint32_t> const & cpg_pos,
                 std::vector<uint16_t> const & cpg_config)
 {
-    for (size_t i; i < cpg_pos.size(); i++)
+    assert(cpg_config.size() == cpg_pos.size());
+
+    auto disc = calculate_discordance_per_read(cpg_config);
+    auto trans = calculate_transitions_per_read(cpg_config);
+
+    for (size_t i = 0; i < cpg_pos.size(); i++)
     {
         GenomePosition pos;
         pos.ref_id = reference_id;
@@ -63,28 +79,28 @@ void insert_CpG(size_t const & reference_id,
         if (it != all_CpGs.end())
         {
             std::get<0>(it->second)++;
-            std::get<1>(it->second) += calculate_discordance_per_read(cpg_config);
-            std::get<2>(it->second) += calculate_transitions_per_read(cpg_config);
+            std::get<1>(it->second) += disc;
+            std::get<2>(it->second) += trans;
             std::get<3>(it->second) += cpg_config[i];
         }
         else
         {
-            all_CpGs.insert(std::make_pair(pos, std::make_tuple(1, calculate_discordance_per_read(cpg_config), calculate_transitions_per_read(cpg_config), cpg_config[i])));
+            all_CpGs.insert(std::make_pair(pos, std::make_tuple(1, disc, trans, cpg_config[i])));
         }
     }
 }
 
 // Insert kmer into map to store it until all BAM records are read
-void insert_kmer(size_t const & reference_id,
+inline void insert_kmer(size_t const & reference_id,
                  size_t const & reference_position,
                  std::map<GenomePosition, std::vector<uint32_t> > & all_kmers,
-                 std::vector<uint16_t> const & cpg_pos,
+                 std::vector<uint32_t> const & cpg_pos,
                  std::vector<uint16_t> const & cpg_config)
 {
     if (cpg_pos.size() < 4)
         return;
 
-    for (size_t i; i < (cpg_pos.size() - 3); i++)
+    for (size_t i = 0; i < (cpg_pos.size() - 3); i++)
     {
         GenomePosition pos;
         pos.ref_id = reference_id;
@@ -106,7 +122,7 @@ void insert_kmer(size_t const & reference_id,
 }
 
 // Internal function to process a single BAM record
-bool process_bam_record_impl(std::ofstream & output_stream,
+inline bool process_bam_record_impl(std::ofstream & output_stream,
                              read_type const & tag,
                              size_t const & reference_id,
                              size_t const & reference_position,
@@ -114,7 +130,7 @@ bool process_bam_record_impl(std::ofstream & output_stream,
                              std::string const & id,
                              std::deque<std::string> const & ref_ids,
                              std::vector<seqan3::dna5_vector> const & genome_seqs,
-                             std::vector<uint16_t> & cpg_pos,
+                             std::vector<uint32_t> & cpg_pos,
                              std::vector<uint16_t> & cpg_config)
 {
     // Define look-up for methylated or unmethylated CpGs (depending on base that needs to be evaluated).
@@ -122,6 +138,9 @@ bool process_bam_record_impl(std::ofstream & output_stream,
     static constexpr std::array<char, 2> methyl_context_char = {'g', 'G'};
 
     // Extract reference sequence matching the reads.
+    assert(reference_id < genome_seqs.size());
+    assert(reference_position + sequence.size() <= genome_seqs[reference_id].size());
+
     seqan3::dna5_vector ref_sequence = genome_seqs[reference_id]
 				                     | seqan3::views::slice(reference_position, reference_position + sequence.size())
 				                     | seqan3::ranges::to<seqan3::dna5_vector>();
@@ -167,7 +186,7 @@ bool process_bam_record_impl(std::ofstream & output_stream,
         return skip;
 
     // Prepare output
-    uint16_t num_methyl_cpgs = std::accumulate(cpg_config.begin(), cpg_config.end(), 0);
+    uint16_t num_methyl_cpgs = std::accumulate(cpg_config.begin(), cpg_config.end(), uint16_t{0});
 
     output_stream << ref_ids[reference_id] << "\t"
                   << reference_position << "\t"
@@ -188,7 +207,7 @@ bool process_bam_record_impl(std::ofstream & output_stream,
 }
 
 // Outer wrapper function overload for single read score only
-void process_bam_record(std::ofstream & output_stream,
+inline void process_bam_record(std::ofstream & output_stream,
                         read_type const & tag,
                         size_t const & reference_id,
                         size_t const & reference_position,
@@ -200,7 +219,7 @@ void process_bam_record(std::ofstream & output_stream,
                         std::map<GenomePosition, std::vector<uint32_t> > & all_kmers,
                         score_tag<false, false>)
 {
-    std::vector<uint16_t> cpg_pos;
+    std::vector<uint32_t> cpg_pos;
     std::vector<uint16_t> cpg_config;
 
     process_bam_record_impl(output_stream,
@@ -216,7 +235,7 @@ void process_bam_record(std::ofstream & output_stream,
 }
 
 // Outer wrapper function overload for PDR/RTS scores
-void process_bam_record(std::ofstream & output_stream,
+inline void process_bam_record(std::ofstream & output_stream,
                         read_type const & tag,
                         size_t const & reference_id,
                         size_t const & reference_position,
@@ -228,7 +247,7 @@ void process_bam_record(std::ofstream & output_stream,
                         std::map<GenomePosition, std::vector<uint32_t> > & all_kmers,
                         score_tag<true, false>)
 {
-    std::vector<uint16_t> cpg_pos;
+    std::vector<uint32_t> cpg_pos;
     std::vector<uint16_t> cpg_config;
 
     bool skip = process_bam_record_impl(output_stream,
@@ -250,7 +269,7 @@ void process_bam_record(std::ofstream & output_stream,
 }
 
 // Outer wrapper function overload for entropy/epipolymorphism scores
-void process_bam_record(std::ofstream & output_stream,
+inline void process_bam_record(std::ofstream & output_stream,
                         read_type const & tag,
                         size_t const & reference_id,
                         size_t const & reference_position,
@@ -262,7 +281,7 @@ void process_bam_record(std::ofstream & output_stream,
                         std::map<GenomePosition, std::vector<uint32_t> > & all_kmers,
                         score_tag<false, true>)
 {
-    std::vector<uint16_t> cpg_pos;
+    std::vector<uint32_t> cpg_pos;
     std::vector<uint16_t> cpg_config;
 
     bool skip = process_bam_record_impl(output_stream,
@@ -283,7 +302,7 @@ void process_bam_record(std::ofstream & output_stream,
 }
 
 // Outer wrapper function overload for all scores
-void process_bam_record(std::ofstream & output_stream,
+inline void process_bam_record(std::ofstream & output_stream,
                         read_type const & tag,
                         size_t const & reference_id,
                         size_t const & reference_position,
@@ -295,7 +314,7 @@ void process_bam_record(std::ofstream & output_stream,
                         std::map<GenomePosition, std::vector<uint32_t> > & all_kmers,
                         score_tag<true, true>)
 {
-    std::vector<uint16_t> cpg_pos;
+    std::vector<uint32_t> cpg_pos;
     std::vector<uint16_t> cpg_config;
 
     bool skip = process_bam_record_impl(output_stream,

--- a/post_processing/summarize_read_level_stats.Rmd
+++ b/post_processing/summarize_read_level_stats.Rmd
@@ -13,8 +13,8 @@ params:
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.20)
+
+add_library (${PROJECT_NAME}_lib INTERFACE)
+target_include_directories (${PROJECT_NAME}_lib INTERFACE "${${PROJECT_NAME}_SOURCE_DIR}/include")
+target_link_libraries (${PROJECT_NAME}_lib INTERFACE seqan3::seqan3 sharg::sharg)
 
 add_executable ("${PROJECT_NAME}" RLM.cpp)
-target_link_libraries ("${PROJECT_NAME}" PUBLIC seqan3::seqan3 sharg::sharg)
+target_link_libraries (${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)

--- a/src/RLM.cpp
+++ b/src/RLM.cpp
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                                  RLM
 // ==========================================================================
-// Copyright (c) 2021-2025, Sara Hetzel <hetzel @ molgen.mpg.de>
-// Copyright (c) 2021-2025, Max-Planck-Institut für Molekulare Genetik
+// Copyright (c) 2021-2026, Sara Hetzel <hetzel @ molgen.mpg.de>
+// Copyright (c) 2021-2026, Max-Planck-Institut für Molekulare Genetik
 // All rights reserved.
 //
 // This file is part of RLM.
@@ -20,11 +20,16 @@
 // ==========================================================================
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
+#include <iostream>
 #include <numeric>
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <variant>
 #include <vector>
 
 #include <sharg/all.hpp>
@@ -69,30 +74,30 @@ int main(int argc, char ** argv)
     try
     {
          parser.parse();
-    }
-    catch (sharg::parser_error const & ext)
-    {
-        seqan3::debug_stream << "Parsing error. " << ext.what() << "\n";
-        return -1;
-    }
 
-    // Get score enum
-    score_type score = _score_name_to_enum(args.score);
+        // Get score enum
+        score_type score = _score_name_to_enum(args.score);
 
-    try
-    {
         switch (score)
         {
             case score_type::SINGLE_READ:  return arg_conv1<false, false>(args);
             case score_type::PDR:          return arg_conv1<true, false>(args);
             case score_type::ENTROPY:      return arg_conv1<false, true>(args);
             case score_type::ALL:          return arg_conv1<true, true>(args);
-            default: throw "Undefined score requested.";
         }
+
+        throw std::runtime_error("Undefined score requested.");
     }
-    catch (const char * e)
+
+    catch (sharg::parser_error const & ext)
     {
-        std::cerr << "Error: " << e << std::endl;
+        seqan3::debug_stream << "Parsing error. " << ext.what() << "\n";
+        return -1;
+    }
+
+    catch (std::exception const & e)
+    {
+        std::cerr << "Error: " << e.what() << '\n';
         return -1;
     }
 }
@@ -105,8 +110,8 @@ int arg_conv1(cmd_arguments & args)
     {
         case sequencing_type::RRBS:  return arg_conv2<calc_pdr_score, calc_entropy_score, true>(args);
         case sequencing_type::WGBS:  return arg_conv2<calc_pdr_score, calc_entropy_score, false>(args);
-        default: throw "Undefined sequencing type requested.";
     }
+    throw std::runtime_error("Undefined sequencing type requested.");
 }
 
 template <bool calc_pdr_score,  bool calc_entropy_score, bool rrbs>
@@ -117,8 +122,8 @@ int arg_conv2(cmd_arguments & args)
     {
         case mate_type::SE:  return arg_conv3<calc_pdr_score, calc_entropy_score, rrbs, true>(args);
         case mate_type::PE:  return arg_conv3<calc_pdr_score, calc_entropy_score, rrbs, false>(args);
-        default: throw "Undefined sequencing mode requested.";
     }
+    throw std::runtime_error("Undefined sequencing mode requested.");
 }
 
 template <bool calc_pdr_score,  bool calc_entropy_score, bool rrbs, bool single_end>
@@ -132,8 +137,8 @@ int arg_conv3(cmd_arguments & args)
         case align_type::BISMARK:   return real_main<calc_pdr_score, calc_entropy_score, rrbs, single_end, align_type::BISMARK>(args);
         case align_type::SEGEMEHL:  return real_main<calc_pdr_score, calc_entropy_score, rrbs, single_end, align_type::SEGEMEHL>(args);
         case align_type::GEM:       return real_main<calc_pdr_score, calc_entropy_score, rrbs, single_end, align_type::GEM>(args);
-        default: throw "Undefined alignment tool requested.";
     }
+    throw std::runtime_error("Undefined alignment tool requested.");
 }
 
 // Real main function containing the program
@@ -177,17 +182,17 @@ int real_main(cmd_arguments & args)
     try
     {
         if (mapping_file.header().ref_ids().size() != genome_seqs_ids.size())
-            throw "Different number of sequences in references and BAM file.";
+            throw std::runtime_error("Different number of sequences in references and BAM file.");
 
         for (size_t i = 0; i < mapping_file.header().ref_ids().size(); i++)
         {
             if (mapping_file.header().ref_ids()[i] != genome_seqs_ids[i])
-                throw "Different reference sequence order or different reference sequences in fasta and BAM file.";
+                throw std::runtime_error("Different reference sequence order or different reference sequences in fasta and BAM file.");
         }
     }
-    catch (const char * e)
+    catch (std::exception const & e)
     {
-        std::cerr << "Error: " << e << std::endl;
+        std::cerr << "Error: " << e.what() << '\n';
         return -1;
     }
 
@@ -218,21 +223,76 @@ int real_main(cmd_arguments & args)
 
     std::cout << "Starting BAM file processing" << std::endl;
 
+    // Helper: get read_type for any record (defined once, not per-iteration)
+    auto type_of = [&](record_t const & r) -> read_type
+    {
+        if constexpr (aligner == align_type::BSMAP)
+        {
+            return _read_tag_bsmap_to_enum(r.tags().get<"ZS"_tag>());
+        }
+        else if constexpr (aligner == align_type::BISMARK)
+        {
+            return _read_tag_bismark_to_enum(r.tags().get<"XG"_tag>());
+        }
+        else
+        {
+            // SEGEMEHL declares XB tag as string while GEM declares XB tag as char
+            // Therefore no overload for seqan3::sam_tag_type is possible and need to iterate through std::variant types
+            auto current_tag = r.tags().at("XB"_tag);
+            std::string xb_tag;
+
+            std::visit([&xb_tag] (auto && arg)
+            {
+                using T = std::remove_cvref_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, char>)
+                    xb_tag = std::string(1, arg);
+                else if constexpr (std::is_same_v<T, std::string>)
+                    xb_tag = arg;
+                else
+                    throw std::runtime_error("Invalid type for XB tag. Must be either string (segemehl) or char (GEM).");
+            }, current_tag);
+
+            if constexpr (aligner == align_type::SEGEMEHL)
+                return _read_tag_segemehl_to_enum(xb_tag);
+            else
+                return _read_tag_gem_to_enum(xb_tag);
+        }
+    };
+
+    // Helper: filter out records we never want to process
+    auto skip_record = [&](record_t const & rec) -> bool
+    {
+        return ((!static_cast<bool>(rec.flag() & seqan3::sam_flag::paired) && args.mode == "PE") ||
+                static_cast<bool>(rec.flag() & seqan3::sam_flag::unmapped) ||
+                static_cast<bool>(rec.flag() & seqan3::sam_flag::secondary_alignment) ||
+                static_cast<bool>(rec.flag() & seqan3::sam_flag::failed_filter) ||
+                static_cast<bool>(rec.flag() & seqan3::sam_flag::duplicate) ||
+                static_cast<bool>(rec.flag() & seqan3::sam_flag::supplementary_alignment) ||
+                rec.mapping_quality() < args.mapq_filter);
+    };
+
+    // Helper: call process_bam_record with the shared argument tail (reduces repetition & mistakes)
+    auto process = [&](read_type tag, record_t const & r)
+    {
+        process_bam_record(output_stream,
+                           tag,
+                           r.reference_id().value(),
+                           r.reference_position().value(),
+                           r.sequence(),
+                           r.id(),
+                           mapping_file.header().ref_ids(),
+                           genome_seqs,
+                           all_CpGs,
+                           all_kmers,
+                           score_tag{});
+    };
+
     for (auto & rec : mapping_file)
     {
         // Check if read is properly mapped and paired (if PE mode), not vendor-failed, not supplementary
         // or secondary alignment and not PCR duplicate
-        if ((!static_cast<bool>(rec.flag() & seqan3::sam_flag::paired) && args.mode == "PE") ||
-            static_cast<bool>(rec.flag() & seqan3::sam_flag::unmapped) ||
-            static_cast<bool>(rec.flag() & seqan3::sam_flag::secondary_alignment) ||
-            static_cast<bool>(rec.flag() & seqan3::sam_flag::failed_filter) ||
-            static_cast<bool>(rec.flag() & seqan3::sam_flag::duplicate) ||
-            static_cast<bool>(rec.flag() & seqan3::sam_flag::supplementary_alignment) ||
-            rec.mapping_quality() < args.mapq_filter)
+        if (skip_record(rec))
             continue;
-
-        // Set tag depending on aligner
-        read_type rec_type;
 
         // Check if alignment contains indels: If yes, skip record.
         using seqan3::get;
@@ -240,10 +300,13 @@ int real_main(cmd_arguments & args)
         bool soft_clip = false;
         for (auto c : rec.cigar_sequence())
         {
-            if (get<seqan3::cigar::operation>(c) != 'M'_cigar_operation &&
-                get<seqan3::cigar::operation>(c) != 'H'_cigar_operation)
+            auto op = get<seqan3::cigar::operation>(c);
+            if (op != 'M'_cigar_operation &&
+                op != 'H'_cigar_operation &&
+                op != '='_cigar_operation &&
+                op != 'X'_cigar_operation)
             {
-                if (get<seqan3::cigar::operation>(c) == 'S'_cigar_operation)
+                if (op == 'S'_cigar_operation)
                 {
                     soft_clip = true;
                 }
@@ -255,26 +318,35 @@ int real_main(cmd_arguments & args)
             }
         }
 
+        // Set tag depending on aligner
+        // Note: two mates of a pair always have the same read type
+        read_type rec_type;
+        try { rec_type = type_of(rec); }
+        catch (std::exception const & e)
+        {
+            std::cerr << "Error: " << e.what() << '\n';
+            return -1;
+        }
+
         if (indel)
         {
             if constexpr(!single_end)
             {
                 if (records.find(rec.id()) != records.end())
                 {
-                    process_bam_record(output_stream,
-                                       rec_type,
-                                       records.at(rec.id()).reference_id().value(),
-                                       records.at(rec.id()).reference_position().value(),
-                                       records.at(rec.id()).sequence(),
-                                       records.at(rec.id()).id(),
-                                       mapping_file.header().ref_ids(),
-                                       genome_seqs,
-                                       all_CpGs,
-                                       all_kmers,
-                                       score_tag{});
+                    // Process stored mate record; derive type from the stored record itself
+                    auto & mate = records.at(rec.id());
+                    read_type mate_type;
+                    try { mate_type = type_of(mate); }
+                    catch (std::exception const & e)
+                    {
+                        std::cerr << "Error: " << e.what() << '\n';
+                        return -1;
+                    }
+
+                    process(mate_type, mate);
                     records.erase(rec.id());
                 }
-
                 else if (mates_with_indels.find(rec.id()) != mates_with_indels.end())
                     mates_with_indels.erase(rec.id());
                 else
@@ -319,58 +391,14 @@ int real_main(cmd_arguments & args)
             }
         }
 
-        if constexpr (aligner == align_type::BSMAP)
-        {
-            rec_type = _read_tag_bsmap_to_enum(rec.tags().get<"ZS"_tag>());
-        }
-        else if constexpr (aligner == align_type::BISMARK)
-        {
-            rec_type = _read_tag_bismark_to_enum(rec.tags().get<"XG"_tag>());
-        }
-        else
-        {
-            // SEGEMEHL declares XB tag as string while GEM declares XB tag as char
-            // Therefore no overload for seqan3::sam_tag_type is possible and need to iterate through
-            // std::variant types
-            try
-            {
-                auto current_tag = rec.tags()["XB"_tag];
-
-                std::string xb_tag;
-
-                std::visit([&xb_tag] (auto && arg)
-                {
-                    using T = std::remove_cvref_t<decltype(arg)>;
-
-                    if constexpr(std::is_same_v<T, char>)
-                    {
-                        xb_tag = std::string(1, arg);
-                    }
-                    else if constexpr (std::is_same_v<T, std::string>)
-                    {
-                        xb_tag = arg;
-                    }
-                    else
-                    {
-                        throw "Invalid type for XB tag. Must be either string (segemehl) or char (GEM).";
-                    }
-                }, current_tag);
-
-                if constexpr (aligner == align_type::SEGEMEHL)
-                    rec_type = _read_tag_segemehl_to_enum(xb_tag);
-                else
-                    rec_type = _read_tag_gem_to_enum(xb_tag);
-            }
-            catch (const char * e)
-            {
-                std::cerr << "Error: " << e << std::endl;
-                return -1;
-            }
-        }
-
         // If RRBS mode, omit potentially artificial bases (should not be applied if already trimmed/accounted for)
         if constexpr (rrbs)
         {
+            // Guard: soft-clipping can shrink aligned sequence dramatically even if raw reads are >=50bp.
+            // Prevent size_t underflow in size()-2 and invalid slicing.
+            if (rec.sequence().size() < 3)
+                continue;
+
             if ((rec_type == read_type::FWD && !static_cast<bool>(rec.flag() & seqan3::sam_flag::on_reverse_strand)) ||
                 (rec_type == read_type::REV && static_cast<bool>(rec.flag() & seqan3::sam_flag::on_reverse_strand)))
             {
@@ -389,158 +417,81 @@ int real_main(cmd_arguments & args)
 
         if constexpr (single_end)
         {
-            process_bam_record(output_stream,
-                               rec_type,
-                               rec.reference_id().value(),
-                               rec.reference_position().value(),
-                               rec.sequence(),
-                               rec.id(),
-                               mapping_file.header().ref_ids(),
-                               genome_seqs,
-                               all_CpGs,
-                               all_kmers,
-                               score_tag{});
+            process(rec_type, rec);
         }
         else
         {
             if (static_cast<bool>(rec.flag() & seqan3::sam_flag::mate_unmapped))
             {
                 // If mate is unmapped just process read immediately
-                process_bam_record(output_stream,
-                                   rec_type,
-                                   rec.reference_id().value(),
-                                   rec.reference_position().value(),
-                                   rec.sequence(),
-                                   rec.id(),
-                                   mapping_file.header().ref_ids(),
-                                   genome_seqs,
-                                   all_CpGs,
-                                   all_kmers,
-                                   score_tag{});
+                process(rec_type, rec);
                 continue;
             }
             else if (mates_with_indels.find(rec.id()) != mates_with_indels.end())
             {
                 // If mate had indel just process read immediately
-                process_bam_record(output_stream,
-                                   rec_type,
-                                   rec.reference_id().value(),
-                                   rec.reference_position().value(),
-                                   rec.sequence(),
-                                   rec.id(),
-                                   mapping_file.header().ref_ids(),
-                                   genome_seqs,
-                                   all_CpGs,
-                                   all_kmers,
-                                   score_tag{});
+                process(rec_type, rec);
                 mates_with_indels.erase(rec.id());
                 continue;
             }
 
             // Check if mate has already been read
-            if (!records.insert(std::make_pair(rec.id(), rec)).second)
+            if (records.insert({rec.id(), rec}).second)
+                continue;
+
+            // Check if reads are overlapping
+            auto & mate = records.at(rec.id());
+
+            int64_t pos1 = static_cast<int64_t>(mate.reference_position().value());
+            int64_t pos2 = static_cast<int64_t>(rec.reference_position().value());
+            int64_t len1 = static_cast<int64_t>(mate.sequence().size());
+            int64_t len2 = static_cast<int64_t>(rec.sequence().size());
+            int64_t end1 = pos1 + len1;
+            int64_t end2 = pos2 + len2;
+
+            int64_t overlap = std::min(end1, end2) - std::max(pos1, pos2);
+
+            if (overlap >= 0 && (rec.reference_id().value() == mate.reference_id().value()))
             {
-                // Check if reads are overlapping
-                int overlap = std::min(records.at(rec.id()).sequence().size() + records.at(rec.id()).reference_position().value(),
-                                       rec.sequence().size() + rec.reference_position().value()) -
-                              std::max(records.at(rec.id()).reference_position().value(), rec.reference_position().value());
-
-                if (overlap >= 0 & (rec.reference_id().value() == records.at(rec.id()).reference_id().value()))
+                // First check if one read is included in the other - just process the longer one in this case
+                if (overlap == len1)
                 {
-                    // First check if one read is included in the other - just process the longer one in this case
-                    if (overlap == records.at(rec.id()).sequence().size())
-                    {
-                        // First read included in second read
-                        process_bam_record(output_stream,
-                                           rec_type,
-                                           rec.reference_id().value(),
-                                           rec.reference_position().value(),
-                                           rec.sequence(),
-                                           rec.id(),
-                                           mapping_file.header().ref_ids(),
-                                           genome_seqs,
-                                           all_CpGs,
-                                           all_kmers,
-                                           score_tag{});
+                    // First read included in second read
+                    process(rec_type, rec);
 
-                    }
-                    else if (overlap == rec.sequence().size())
-                    {
-                        // Second read included in first read
-                        process_bam_record(output_stream,
-                                           rec_type,
-                                           records.at(rec.id()).reference_id().value(),
-                                           records.at(rec.id()).reference_position().value(),
-                                           records.at(rec.id()).sequence(),
-                                           records.at(rec.id()).id(),
-                                           mapping_file.header().ref_ids(),
-                                           genome_seqs,
-                                           all_CpGs,
-                                           all_kmers,
-                                           score_tag{});
-                    }
-                    else
-                    {
-                        // Merge reads
-                        // Determine which read comes first
-                        bool is_first = records.at(rec.id()).reference_position().value() <= rec.reference_position().value();
-                        auto & rec1 = is_first ? records.at(rec.id()) : rec;
-                        auto & rec2 = is_first ? rec : records.at(rec.id());
-
-                        seqan3::dna5_vector second_seq_part = rec2.sequence()
-                                                            | seqan3::views::slice(overlap, rec2.sequence().size())
-                                                            | seqan3::ranges::to<seqan3::dna5_vector>();
-                        rec1.sequence().insert(rec1.sequence().end(), second_seq_part.begin(), second_seq_part.end());
-
-                        process_bam_record(output_stream,
-                                           rec_type,
-                                           rec1.reference_id().value(),
-                                           rec1.reference_position().value(),
-                                           rec1.sequence(),
-                                           rec1.id(),
-                                           mapping_file.header().ref_ids(),
-                                           genome_seqs,
-                                           all_CpGs,
-                                           all_kmers,
-                                           score_tag{});
-                    }
+                }
+                else if (overlap == len2)
+                {
+                    // Second read included in first read
+                    process(rec_type, mate);
                 }
                 else
                 {
-                    // Process both mate records
-                    // Record already stored in map
-                    process_bam_record(output_stream,
-                                       rec_type,
-                                       records.at(rec.id()).reference_id().value(),
-                                       records.at(rec.id()).reference_position().value(),
-                                       records.at(rec.id()).sequence(),
-                                       records.at(rec.id()).id(),
-                                       mapping_file.header().ref_ids(),
-                                       genome_seqs,
-                                       all_CpGs,
-                                       all_kmers,
-                                       score_tag{});
-                    // Current record
-                    process_bam_record(output_stream,
-                                       rec_type,
-                                       rec.reference_id().value(),
-                                       rec.reference_position().value(),
-                                       rec.sequence(),
-                                       rec.id(),
-                                       mapping_file.header().ref_ids(),
-                                       genome_seqs,
-                                       all_CpGs,
-                                       all_kmers,
-                                       score_tag{});
-                }
+                    // Merge reads
+                    // Determine which read comes first
+                    bool is_first = mate.reference_position().value() <= rec.reference_position().value();
+                    auto & rec1 = is_first ? mate : rec;
+                    auto & rec2 = is_first ? rec : mate;
 
-                // Remove from map, now not used anymore
-                records.erase(rec.id());
+                    size_t ov = static_cast<size_t>(overlap);
+                    seqan3::dna5_vector second_seq_part = rec2.sequence()
+                                                        | seqan3::views::slice(ov, rec2.sequence().size())
+                                                        | seqan3::ranges::to<seqan3::dna5_vector>();
+                    rec1.sequence().insert(rec1.sequence().end(), second_seq_part.begin(), second_seq_part.end());
+
+                    process(rec_type, rec1);
+                }
             }
             else
             {
-                continue;
+                // Process both mate records
+                // Record already stored in map
+                process(rec_type, mate);
+                process(rec_type, rec);
             }
+
+            // Remove from map, now not used anymore
+            records.erase(rec.id());
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.8)
+# SPDX-FileCopyrightText: 2006-2025 Knut Reinert & Freie Universität Berlin
+# SPDX-FileCopyrightText: 2016-2025 Knut Reinert & MPI für molekulare Genetik
+# SPDX-License-Identifier: CC0-1.0
+
+cmake_minimum_required (VERSION 3.20)
 
 # Set directories for test output files, input data and binaries.
 file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)
@@ -6,84 +10,15 @@ add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
 add_definitions (-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
 add_definitions (-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
-# Define cmake configuration flags to configure and build external projects with the same flags as specified for
-# this project.
-set (SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "")
-list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
-list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
-list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}")
-list (APPEND SEQAN3_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}")
-set (SEQAN3_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")
+# This includes `cmake/test/config.cmake` which takes care of setting up the test infrastructure. It also provides
+# the `add_app_test` macro, which is used to add tests to the CMake test suite.
+include("${PROJECT_SOURCE_DIR}/cmake/test/config.cmake")
 
-include ("${SEQAN3_CLONE_DIR}/test/cmake/seqan3_require_test.cmake")
-
-seqan3_require_test ()
-
-# Build tests just before their execution, because they have not been built with "all" target.
-# The trick is here to provide a cmake file as a directory property that executes the build command.
-file (WRITE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake"
-            "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target api_test)\n"
-            "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target cli_test)")
-set_directory_properties (PROPERTIES TEST_INCLUDE_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake")
-
-# Define the test targets. All depending targets are built just before the test execution.
-add_custom_target (api_test)
-add_custom_target (cli_test)
-
-# Test executables and libraries should not mix with the application files.
-unset (CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-unset (CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-unset (CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-
-# A macro that adds an api or cli test.
-macro (add_app_test test_filename test_alternative)
-    # Extract the test target name.
-    file (RELATIVE_PATH source_file "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${test_filename}")
-    get_filename_component (target "${source_file}" NAME_WE)
-
-    # Create the test target.
-    add_executable (${target} ${test_filename})
-    target_link_libraries (${target} seqan3::seqan3 gtest gtest_main)
-
-    # Make seqan3::test available for both cli and api tests.
-    target_include_directories(${target} PUBLIC "${SEQAN3_CLONE_DIR}/test/include")
-    target_include_directories(${target} PUBLIC "${SEQAN3_TEST_CLONE_DIR}/googletest/include/")
-
-    # Add the test to its general target (cli or api).
-    if (${test_alternative} STREQUAL "CLI_TEST")
-        add_dependencies (${target} "${PROJECT_NAME}") # cli test needs the application executable
-        add_dependencies (cli_test ${target})
-    elseif (${test_alternative} STREQUAL "API_TEST")
-        add_dependencies (api_test ${target})
-    endif ()
-
-    # Generate and set the test name.
-    get_filename_component (target_relative_path "${source_file}" DIRECTORY)
-    if (target_relative_path)
-        set (test_name "${target_relative_path}/${target}")
-    else ()
-        set (test_name "${target}")
-    endif ()
-    add_test (NAME "${test_name}" COMMAND ${target})
-
-    unset (source_file)
-    unset (target)
-    unset (test_name)
-endmacro ()
-
-# A macro that adds an api test.
-macro (add_api_test test_filename)
-    add_app_test (${test_filename} API_TEST)
-endmacro ()
-
-# A macro that adds a cli test.
-macro (add_cli_test test_filename)
-    add_app_test (${test_filename} CLI_TEST)
-endmacro ()
-
-# Fetch data and add the tests.
+# This makes test data available
 include (data/datasources.cmake)
+
+# If you previously had subfolders that call add_api_test/add_cli_test, keep them:
 add_subdirectory (api)
 add_subdirectory (cli)
 
-message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")
+message (STATUS "${FontBold}You can run `make check` to build and run tests.${FontReset}")

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.20)
 
-add_api_test (scores_test.cpp)
+add_app_test (scores_test.cpp)

--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.20)
 
-add_cli_test (rlm_options_test.cpp)
+add_app_test (rlm_options_test.cpp)
 target_use_datasources (rlm_options_test FILES chrM.fa)
 
-add_cli_test (rlm_single_read_test.cpp)
+add_app_test (rlm_single_read_test.cpp)
 target_use_datasources (rlm_single_read_test FILES chrM.fa)
 target_use_datasources (rlm_single_read_test FILES test_ref.fa)
 target_use_datasources (rlm_single_read_test FILES test_skipped_reads.sam)
@@ -19,7 +19,7 @@ target_use_datasources (rlm_single_read_test FILES test_single_reads_name_sorted
 target_use_datasources (rlm_single_read_test FILES control_single_reads.bed)
 target_use_datasources (rlm_single_read_test FILES control_single_reads_rrbs.bed)
 
-add_cli_test (rlm_aligner_test.cpp)
+add_app_test (rlm_aligner_test.cpp)
 target_use_datasources (rlm_single_read_test FILES test_ref.fa)
 target_use_datasources (rlm_single_read_test FILES test_bsmap.bam)
 target_use_datasources (rlm_single_read_test FILES test_bismark.bam)

--- a/test/cli/rlm_options_test.cpp
+++ b/test/cli/rlm_options_test.cpp
@@ -10,7 +10,7 @@ TEST_F(RLM, no_options)
         "RLM - Read level DNA methylation analysis of bisulfite converted sequencing data.\n"
         "=================================================================================\n"
         "    RLM [-d|--rrbs] -b|--bam path -r|--reference path -m|--mode string\n"
-        "    -s|--score string [-a|--aligner string] [-c|--coverage uint32]\n"
+        "    [-s|--score string] [-a|--aligner string] [-c|--coverage uint32]\n"
         "    [-q|--mapping_quality uint32] [-o|--output_single_read path]\n"
         "    [-e|--output_entropy path] [-p|--output_pdr path]\n"
         "    Try -h or --help for more information.\n"

--- a/test/cli/rlm_options_test.cpp
+++ b/test/cli/rlm_options_test.cpp
@@ -9,6 +9,10 @@ TEST_F(RLM, no_options)
     {
         "RLM - Read level DNA methylation analysis of bisulfite converted sequencing data.\n"
         "=================================================================================\n"
+        "    RLM [-d|--rrbs] -b|--bam path -r|--reference path -m|--mode string\n"
+        "    -s|--score string [-a|--aligner string] [-c|--coverage uint32]\n"
+        "    [-q|--mapping_quality uint32] [-o|--output_single_read path]\n"
+        "    [-e|--output_entropy path] [-p|--output_pdr path]\n"
         "    Try -h or --help for more information.\n"
     };
 

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.20)
 
 include (cmake/app_datasources.cmake)
 


### PR DESCRIPTION
This PR ...

- updates SeqAn3 and sharg (switch to CPM dependency management instead of submodules)
- fixes a few potential issues in the code and adds safety via new asserts
- adjusts the tests to the new repo structure